### PR TITLE
CI: 修复 pre-push 架构验证脚本的超时处理

### DIFF
--- a/scripts/validate-architecture.sh
+++ b/scripts/validate-architecture.sh
@@ -107,6 +107,8 @@ else
     BUILD_RESULT=0
     TIMEOUT_OCCURRED=0
     
+    # Temporarily disable 'exit on error' to capture build exit codes safely
+    set +e
     if command -v timeout &> /dev/null; then
         # Use GNU timeout (60 seconds)
         timeout 60 make build > /dev/null 2>&1
@@ -126,6 +128,8 @@ else
         make build > /dev/null 2>&1
         BUILD_RESULT=$?
     fi
+    # Re-enable 'exit on error' for subsequent checks
+    set -e
 
     if [ $TIMEOUT_OCCURRED -eq 1 ]; then
         echo -e "${YELLOW}⚠️  WARNING: Hugo build timed out (60s). Docker might be hung.${NC}"


### PR DESCRIPTION
问题\n- pre-push 钩子在执行架构验证时，调用 `timeout 60 make build` 若发生超时（退出码 124），因脚本头部 `set -e` 生效导致脚本立即退出，从而阻断 push。\n\n修复\n- 在构建验证阶段临时 `set +e`，执行后捕获退出码并恢复 `set -e`。\n- 当检测到超时（124）时仅提示警告并跳过构建验证，不计为错误；非超时失败则计入错误。\n\n影响范围\n- 仅修改 `scripts/validate-architecture.sh`，不涉及其他代码或文档。\n- 验证通过：\n  - 模板合规检查通过\n  - CSS检查通过（超大行数仅警告）\n  - 构建在超时场景下不再阻断 push（提示检查 Docker 并手动 `make build`）。\n\n备注\n- 按照项目约定，验证与构建均通过 `make` 执行；未改动任何与 Hugo 服务启停相关逻辑。